### PR TITLE
Feature/pre commit linter actions

### DIFF
--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -20,8 +20,12 @@ jobs:
         sudo apt update
     - name: Install system hooks
       run: sudo apt install -qq ros-jazzy-ament-cmake-uncrustify
-    - name: Setup system hooks
-      run: source /opt/ros/jazzy/setup.bash
-    - uses: pre-commit/action@v3.0.1
+    - name: Install pre-commit
+      run: python -m pip install pre-commit && python -m pip freeze --local
+      shell: bash
+    - uses: actions/cache@v4
       with:
-        extra_args: --all-files --hook-stage manual
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: source /opt/ros/jazzy/setup.bash && pre-commit run --show-diff-on-failure --color=always --all-files
+      shell: bash

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -6,18 +6,16 @@ on:
 jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/naturerobots/ros2_jazzy_build:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options:
+        --user root
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.10.6 
-    - name: Install system hooks
-      run: sudo add-apt-repository universe &&\
-           sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg &&\
-           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
-           sudo apt update &&\
-           sudo apt install -qq ros-jazzy-ament-uncrustify\
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -6,16 +6,20 @@ on:
 jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/naturerobots/ros2_jazzy_build:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options:
-        --user root
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.10.6 
+    - name: Setup ROS pkg sources
+      run: |
+        sudo add-apt-repository universe &&\
+        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg &&\
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
+        sudo apt update
+    - name: Install system hooks
+      run: sudo apt install -qq ament-cmake-uncrustify
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -12,6 +12,8 @@ jobs:
       packages: read
     container:
       image: ghcr.io/naturerobots/ros2_humble_build:latest
+      env:
+        PRE_COMMIT_HOME: /cache/pre-commit
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -22,6 +24,13 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10.6'
+    - name: Set up pre-commit cache
+      uses: actions/cache@v4
+      with:
+        path: /cache/pre-commit
+        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+            ${{ runner.os }}-pre-commit-
     - uses: pre-commit/action@v3.0.1
       with:
-        extra_args: --all-files --hook-stage manual
+        extra_args: --all-files

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -7,9 +7,6 @@ jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     container:
       image: ghcr.io/naturerobots/ros2_jazzy_build:latest
       credentials:

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       packages: read
     container:
-      image: ghcr.io/naturerobots/ros2_humble_build:latest
+      image: ghcr.io/naturerobots/ros2_jazzy_build:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -18,8 +18,10 @@ jobs:
         sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg &&\
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
         sudo apt update
-    - name: Install and setup system hooks
-      run: sudo apt install -qq ros-jazzy-ament-uncrustify && source /opt/ros/jazzy/setup.sh
+    - name: Install system hooks
+      run: sudo apt install -qq ros-jazzy-ament-cmake-uncrustify
+    - name: Setup system hooks
+      run: source /opt/ros/jazzy/setup.bash
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -19,6 +19,9 @@ jobs:
         --user root
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10.6'
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -13,7 +13,11 @@ jobs:
       with:
         python-version: 3.10.6 
     - name: Install system hooks
-      run: sudo apt install -qq ros-jazzy-ament-uncrustify
+      run: sudo add-apt-repository universe &&\
+           sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg &&\
+           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
+           sudo apt update &&\
+           sudo apt install -qq ros-jazzy-ament-uncrustify\
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -1,0 +1,19 @@
+name: Linters via pre commit
+
+on:
+  workflow_call:
+
+jobs:
+  linters_via_pre_commit:
+    name: Linters via pre commit
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.10.6 
+    - name: Install system hooks
+      run: sudo apt install -qq ament-cmake-uncrustify
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -18,8 +18,8 @@ jobs:
         sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg &&\
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
         sudo apt update
-    - name: Install system hooks
-      run: sudo apt install -qq ros-jazzy-ament-uncrustify
+    - name: Install and setup system hooks
+      run: sudo apt install -qq ros-jazzy-ament-uncrustify && source /opt/ros/jazzy/setup.sh
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -19,9 +19,6 @@ jobs:
         --user root
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.10.6'
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -12,8 +12,6 @@ jobs:
       packages: read
     container:
       image: ghcr.io/naturerobots/ros2_humble_build:latest
-      env:
-        PRE_COMMIT_HOME: /cache/pre-commit
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -24,13 +22,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10.6'
-    - name: Set up pre-commit cache
-      uses: actions/cache@v4
-      with:
-        path: /cache/pre-commit
-        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: |
-            ${{ runner.os }}-pre-commit-
     - uses: pre-commit/action@v3.0.1
       with:
-        extra_args: --all-files
+        extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -27,5 +27,6 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    # Consider using uncrustify without the ament wrapper. Then, we can use the pre-commit action and do not need to use the ROS pkg sources.
     - run: source /opt/ros/jazzy/setup.bash && pre-commit run --show-diff-on-failure --color=always --all-files
       shell: bash

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -6,14 +6,14 @@ on:
 jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: 3.10.6 
     - name: Install system hooks
-      run: sudo apt install -qq ament-cmake-uncrustify
+      run: sudo apt install -qq ros-jazzy-ament-uncrustify
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       packages: read
     container:
-      image: ghcr.io/naturerobots/ros2_jazzy_build:latest
+      image: ghcr.io/naturerobots/ros2_humble_build:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -19,7 +19,7 @@ jobs:
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null &&\
         sudo apt update
     - name: Install system hooks
-      run: sudo apt install -qq ament-cmake-uncrustify
+      run: sudo apt install -qq ros-jazzy-ament-uncrustify
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual

--- a/.github/workflows/linters_via_pre_commit.yaml
+++ b/.github/workflows/linters_via_pre_commit.yaml
@@ -7,6 +7,9 @@ jobs:
   linters_via_pre_commit:
     name: Linters via pre commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     container:
       image: ghcr.io/naturerobots/ros2_jazzy_build:latest
       credentials:


### PR DESCRIPTION
Add reusable workflow for running pre-commit hooks.

In order to be able to run local hooks, like `ament_uncrustify` (for checking C++ code in accordance with ROS2 guidelines) the workflow installs some jazzy packages. This introduces some ROS distro dependency, which is not so nice, but I didn't find a way around it.