### PR TITLE
Feature/parameterize ros distro

### DIFF
--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -1,7 +1,12 @@
-name: Humble CI - Build and Test
+name: ROS CI - Build and Test
 
 on:
   workflow_call:
+
+inputs:
+  ros_distro:
+    required: true
+    type: string
 
 jobs:
   build_and_test:
@@ -10,7 +15,7 @@ jobs:
       contents: read
       packages: read
     container:
-      image: ghcr.io/naturerobots/ros2_humble_build:latest
+      image: ghcr.io/naturerobots/ros2_${{ inputs.ros_distro }}_build:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +37,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@0.3.13
         with:
           package-name: ${{env.PACKAGES_FOR_CI}}
-          target-ros2-distro: humble
+          target-ros2-distro: ${{ inputs.ros_distro }}
           vcs-repo-file-url: $GITHUB_WORKSPACE/source_dependencies.yaml
           rosdep-check: true
           import-token: ${{ secrets.ORGANIZATION_PRIVATE_PAT }}

--- a/.github/workflows/ros_ci.yaml
+++ b/.github/workflows/ros_ci.yaml
@@ -2,11 +2,10 @@ name: ROS CI - Build and Test
 
 on:
   workflow_call:
-
-inputs:
-  ros_distro:
-    required: true
-    type: string
+    inputs:
+      ros_distro:
+        required: true
+        type: string
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Allow parameterization of the reusable github workflow for ROS2 CI. With this, we can easily run CI for building and testing our code via `colcon` for multiple ROS2 distros (currently supported: `humble` and `jazzy`).

Merging this PR will **break** CI for all repos that already use the workflow, due to me renaming it. I will take care of fixing those.

Find repos in question via [this search](https://github.com/search?q=org%3Anaturerobots%20naturerobots%2Fgithub_automation_public%2F.github%2Fworkflows%2Fhumble_ci.yaml&type=code): mesh_nav, mesh_tools, mbf, mesh_nav_tutorials, (and some internal, private repos)

Fixes #4 